### PR TITLE
Display actual port number rather than assigned port number in server mode

### DIFF
--- a/src/main/java/edu/cmu/cs/lti/ark/fn/SemaforSocketServer.java
+++ b/src/main/java/edu/cmu/cs/lti/ark/fn/SemaforSocketServer.java
@@ -34,7 +34,7 @@ public class SemaforSocketServer {
 		final Semafor semafor = Semafor.getSemaforInstance(modelDirectory);
 		// Set up socket server
 		final ServerSocket serverSocket = new ServerSocket(port);
-		System.err.println("Listening on port: " + port);
+		System.err.println("Listening on port: " + serverSocket.getLocalPort());
 		while (true) {
 			try {
 				final Socket clientSocket = serverSocket.accept();


### PR DESCRIPTION
This is useful if you ask it to run on port zero, as the OS will then assign a
port number:

```
$ java -Xms4g -Xmx4g -cp target/Semafor-3.0-alpha-04.jar edu.cmu.cs.lti.ark.fn.SemaforSocketServer model-dir:/home/wva/semafor_malt_model_20121129  port:0
model-dir:/home/wva/semafor_malt_model_20121129
port:0
Initializing frame identification model...
Reading serialized required data
Done reading serialized required data
Reading graph from: /home/wva/semafor_malt_model_20121129/sparsegraph.gz...
Read graph successfully.
Reading model parameters...
100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 1100000 1200000 1300000 1400000 1500000 1600000 1700000 1800000 1900000 2000000 2100000 2200000 2300000 2400000 2500000 2600000 2700000 2800000 2900000 3000000 Done reading model parameters.
Initializing alphabet for argument identification..
0 100000 200000 300000 400000 500000 600000 700000 800000 900000 1000000 1100000 1200000 1300000 1400000 1500000 1600000 1700000 1800000 1900000 2000000 2100000 2200000 2300000 2400000 2500000 2600000 2700000 2800000 2900000 3000000 
Listening on port: 49230
```
