### PR TITLE
Return  error message in socket server when parseSentence throws an error

### DIFF
--- a/src/main/java/edu/cmu/cs/lti/ark/fn/SemaforSocketServer.java
+++ b/src/main/java/edu/cmu/cs/lti/ark/fn/SemaforSocketServer.java
@@ -46,19 +46,7 @@ public class SemaforSocketServer {
 				final PrintWriter output =
 						new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream(), Charsets.UTF_8));
 				while (sentences.hasNext()) {
-					final Sentence sentence = sentences.next();
-					final long start = System.currentTimeMillis();
-					try {
-					    output.println(semafor.parseSentence(sentence).toJson());
-					} catch (Exception e) {
-					    System.err.println("Error on parsing sentence:" + e);
-					    e.printStackTrace(System.err);
-					    String message = jsonMapper.writeValueAsString(e.toString());
-					    output.println("{\"error\": "+message+"}");
-					}
-					output.flush();
-					final long end = System.currentTimeMillis();
-					System.err.printf("parsed sentence with %d tokens in %d millis.%n", sentence.size(), end - start);
+					processSentence(semafor, sentences.next(), output);
 				}
 				closeQuietly(sentences);
 				closeQuietly(output);
@@ -67,4 +55,20 @@ public class SemaforSocketServer {
 			}
 		}
 	}
+
+	public static void processSentence(Semafor semafor, Sentence sentence, PrintWriter output)
+		throws IOException {
+		final long start = System.currentTimeMillis();
+		try {
+			output.println(semafor.parseSentence(sentence).toJson());
+		} catch (Exception e) {
+			System.err.println("Error on parsing sentence:" + e);
+			e.printStackTrace(System.err);
+			String message = jsonMapper.writeValueAsString(e.toString());
+			output.println("{\"error\": "+message+"}");
+		}
+		output.flush();
+		final long end = System.currentTimeMillis();
+		System.err.printf("parsed sentence with %d tokens in %d millis.%n", sentence.size(), end - start);
+    }
 }


### PR DESCRIPTION
Currently, the socketserver simply does not respond if parseSentence throws an error, causing netcat / the client to hang. 

Proposed change returns a simple {"error": <message>} json to signal that there is a problem.
